### PR TITLE
Fix --append implementation

### DIFF
--- a/graffiti_monkey/core.py
+++ b/graffiti_monkey/core.py
@@ -204,10 +204,6 @@ class GraffitiMonkey(object):
                 value = instance_tags[tag_name]
                 tags_to_set[tag_name] = value
 
-        # Additional tags
-        tags_to_set['instance_id'] = instance_id
-        tags_to_set['device'] = device
-
         # Set default tags for volume
         for tag in self._volume_tags_to_be_set:
             log.debug('Trying to set default tag: %s=%s', tag['key'], tag['value'])

--- a/graffiti_monkey/core.py
+++ b/graffiti_monkey/core.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import copy
 
 from exceptions import *
 
@@ -196,7 +197,7 @@ class GraffitiMonkey(object):
 
         tags_to_set = {}
         if self._append:
-            tags_to_set = volume.tags
+            tags_to_set = copy.deepcopy(volume.tags)
         for tag_name in self._instance_tags_to_propagate:
             log.debug('Trying to propagate instance tag: %s', tag_name)
             if tag_name in instance_tags:
@@ -297,7 +298,7 @@ class GraffitiMonkey(object):
 
         tags_to_set = {}
         if self._append:
-            tags_to_set = snapshot.tags
+            tags_to_set = copy.deepcopy(snapshot.tags)
         for tag_name in self._volume_tags_to_propagate:
             log.debug('Trying to propagate volume tag: %s', tag_name)
             if tag_name in volume_tags:


### PR DESCRIPTION
The current shallow copy implementation of `volume.tags` renders the `--append` flag useless as the volume tags will always match the tags to be set thus resulting in a delta of zero tags to be added.